### PR TITLE
Update node support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "6"
-  - "4"
+  - '8'
+  - '6'
+  - '4'

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "strict-uri-encode": "^2.0.0"
   },
   "devDependencies": {
-    "ava": "*",
-    "execa": "^0.5.0",
-    "xo": "*"
+    "ava": "0.25.0",
+    "execa": "0.10.0",
+    "xo": "0.20.3"
   },
   "xo": {
     "esnext": true,


### PR DESCRIPTION
Support the same node versions as [strict-uri-encode](https://github.com/kevva/strict-uri-encode), the API for this module.